### PR TITLE
hotfix: add pyotp and qrcode dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,5 @@ requests==2.32.5
 sentry-sdk==2.43.0
 django-ratelimit==4.1.0
 colorama==0.4.6
+pyotp==2.9.0
+qrcode==8.0


### PR DESCRIPTION
Fixes deployment error: ModuleNotFoundError: No module named 'pyotp'. Required for 2FA functionality.