### PR TITLE
fix: Remove whitespace around product images

### DIFF
--- a/frontend/src/components/ProductCard.css
+++ b/frontend/src/components/ProductCard.css
@@ -1,24 +1,9 @@
 .product-card-image-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  aspect-ratio: 1 / 1;
-  width: 100%;
-  background: var(--gray-100, #f3f4f6);
   position: relative;
-  overflow: hidden;
-}
-
-.product-card-image {
   width: 100%;
-  height: 100%;
-  object-fit: contain;
-  padding: 12px;
-  transition: transform 0.2s;
-}
-
-.product-card-image-container:hover .product-card-image {
-  transform: scale(1.04);
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  background: white;
 }
 
 /* Card hover/focus effect */

--- a/frontend/src/components/ProductCard.js
+++ b/frontend/src/components/ProductCard.js
@@ -37,36 +37,34 @@ const ProductCard = ({ product, onAddToCart, onQuickView, loading = false, prior
     >
       {/* Product Image Section */}
       <div className="product-card-image-container">
-        <Link to={`/products/${product.id}`} className="block w-full h-full" aria-label={`View ${product.name} details`}>
-          <div className="relative aspect-square overflow-hidden bg-gray-50">
-            {productImage && !imageError ? (
-              <>
-                <img
-                  src={productImage}
-                  alt={product.name ? `${product.name} product image` : 'Product image'}
-                  className={`w-full h-full object-cover transition-transform duration-300 ${imageLoading ? 'opacity-0' : 'opacity-100 group-hover:scale-105'}`}
-                  loading="lazy"
-                  width="300"
-                  height="300"
-                  onLoad={() => setImageLoading(false)}
-                  onError={() => {
-                    setImageError(true);
-                    setImageLoading(false);
-                  }}
-                />
-                {imageLoading && (
-                  <div className="absolute inset-0 bg-gray-200 animate-pulse" />
-                )}
-              </>
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-gray-400" role="img" aria-label="Product placeholder">
-                <svg className="w-20 h-20" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                  <path d="M3 17l6-6 4 4 8-8" />
-                </svg>
-              </div>
-            )}
-          </div>
+        <Link to={`/products/${product.id}`} className="absolute inset-0" aria-label={`View ${product.name} details`}>
+          {productImage && !imageError ? (
+            <>
+              <img
+                src={productImage}
+                alt={product.name ? `${product.name} product image` : 'Product image'}
+                className={`w-full h-full object-cover transition-transform duration-300 ${imageLoading ? 'opacity-0' : 'opacity-100 group-hover:scale-105'}`}
+                loading="lazy"
+                width="300"
+                height="300"
+                onLoad={() => setImageLoading(false)}
+                onError={() => {
+                  setImageError(true);
+                  setImageLoading(false);
+                }}
+              />
+              {imageLoading && (
+                <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+              )}
+            </>
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-gray-400 bg-gray-50" role="img" aria-label="Product placeholder">
+              <svg className="w-20 h-20" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                <path d="M3 17l6-6 4 4 8-8" />
+              </svg>
+            </div>
+          )}
         </Link>
 
         {/* Stock Status Overlays */}


### PR DESCRIPTION
## Problem\nProduct images still had whitespace around them due to:\n- Nested div structure with extra padding\n- object-fit: contain with 12px padding in CSS\n- Gray background showing through\n\n## Solution\n- Simplified image container structure\n- Removed all padding from images\n- Changed to object-cover for full coverage\n- Removed unnecessary nested divs\n\n## Result\n✅ Images fill entire card area\n✅ No gray/white space around images\n✅ Clean, professional appearance\n✅ Matches industry standards