### PR TITLE
fix: Correct API method name in OrderDetail

### DIFF
--- a/frontend/src/pages/OrderDetail.js
+++ b/frontend/src/pages/OrderDetail.js
@@ -17,7 +17,7 @@ const OrderDetail = () => {
   const fetchOrderDetail = async () => {
     try {
       setLoading(true);
-      const response = await ordersAPI.getOrderById(id);
+      const response = await ordersAPI.getOrder(id);
       setOrder(response.data);
     } catch (error) {
       console.error('Error fetching order:', error);


### PR DESCRIPTION
## Problem\nOrderDetail was calling `getOrderById()` which doesn't exist in the API service.\n\n## Solution\nChanged to use `getOrder(id)` which is the correct method name.\n\n## Result\n✅ Order detail page now fetches data correctly\n✅ No more API errors